### PR TITLE
chore(paging): bump version to 2.0.1 and update release notes

### DIFF
--- a/src/Paging/Paging.csproj
+++ b/src/Paging/Paging.csproj
@@ -13,11 +13,13 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Title>Pagination</Title>
 
-		<Version>2.0.0</Version>
+		<Version>2.0.1</Version>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<RepositoryType>git</RepositoryType>
 		<PackageId>Qrtix.Paging</PackageId>
-		<PackageReleaseNotes>Add new extensions methods to paginate</PackageReleaseNotes>
+		<PackageReleaseNotes>
+			- update docs
+		</PackageReleaseNotes>
 
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageTags>Pagination PaginatedList PagedList List Pager Paged Paging</PackageTags>


### PR DESCRIPTION
Updated the package version to 2.0.1 and included new release notes focusing on documentation improvements.